### PR TITLE
Add simple static Ericsson website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
-# Ericcson_demo
+# Ericsson Demo
+
+This repository contains a very simple static website with information about Ericsson.
+
+## Getting Started
+
+You can view the site by opening `index.html` directly in your browser or by running a simple HTTP server:
+
+```bash
+python3 -m http.server 8000
+```
+
+Then navigate to `http://localhost:8000` in your browser.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Ericsson Company</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+    <header>
+        <h1>Welcome to Ericsson</h1>
+    </header>
+    <main>
+        <p>Ericsson is a leading provider of telecommunications equipment and services. Founded in 1876, the company has played a key role in shaping mobile technology worldwide.</p>
+    </main>
+    <footer>
+        <p>&copy; 2024 Ericsson AB. All rights reserved.</p>
+    </footer>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,4 @@
+body { font-family: Arial, sans-serif; margin: 0; padding: 0; }
+header { background-color: #0038a8; color: white; padding: 20px; text-align: center; }
+main { padding: 20px; }
+footer { background-color: #f2f2f2; text-align: center; padding: 10px; margin-top: 20px; }


### PR DESCRIPTION
## Summary
- add initial README with site instructions
- add simple `index.html` page about Ericsson
- add `styles.css` for basic styling

## Testing
- `python3 -m http.server 8000` *(fails: module not found?)*

------
https://chatgpt.com/codex/tasks/task_e_6852c559118c8324994b45b2a1e448c8